### PR TITLE
UserHost command implementation (untested)

### DIFF
--- a/src/main/xgen/irc/commands/UserHostCommand.java
+++ b/src/main/xgen/irc/commands/UserHostCommand.java
@@ -1,0 +1,25 @@
+// UserCommand.java
+
+package xgen.irc.commands;
+
+import xgen.irc.*;
+
+public class UserHostCommand extends Command {
+    
+    public UserHostCommand() {
+        super( "USERHOST" );
+    }
+
+    public void handle( Context context , Connection conn , String line ) {
+        String[] nicknames = line.trim().split( "\\s+" );
+        // for each nickname, if found in room, return ident
+        StringBuilder sb = new StringBuilder();
+        for(String nickname : nicknames) {
+        	if(conn.inRoom(nickname)) {
+        		sb.append(nickname);
+        		sb.append(" is in the room\n");
+        	}
+        }
+        conn.sendMessage(sb.toString());
+    }
+}


### PR DESCRIPTION
It seems that UserHost is required by some clients (mIRC wants it). This implementation simply echoes the nicknames that match the current room.
